### PR TITLE
Fix markdown typo for csync2 link

### DIFF
--- a/3.1.3/source/installation-guide/cluster.md
+++ b/3.1.3/source/installation-guide/cluster.md
@@ -140,7 +140,7 @@ Note, if you want to check the status of OpenDJ replication run the following co
 /opt/opendj/bin/dsreplication status -n -X -h idp1.example.org -p 4444 -D "cn=Directory Manager" -I admin -w <password>
 ```
 
-Next we should (install csync2)[https://linuxaria.com/howto/csync2-a-filesystem-syncronization-tool-for-linux] for file system replication.
+Next we should [install csync2](https://linuxaria.com/howto/csync2-a-filesystem-syncronization-tool-for-linux) for file system replication.
 
 The necessary directories to replicate are as follows:
 


### PR DESCRIPTION
Syntax for markdown link was incorrect - fixed it.